### PR TITLE
Debounce item sorting

### DIFF
--- a/module/init.js
+++ b/module/init.js
@@ -97,6 +97,8 @@ function sortItems(actor) {
   }
 }
 
+const sortItemsDebounced = debounce(sortItems, 200)
+
 Hooks.on('renderActorSheet', (actorSheet, html, data) => {
-  sortItems(actorSheet.actor);
+  sortItemsDebounced(actorSheet.actor);
 });


### PR DESCRIPTION
This prevents the sorter from running too quickly after a sheet render,
as running immediately can lead to infinite render loops. This can be
reproduced fairly easily by creating multiple owned items in quick
succession.

For example, running the following snippet, which quickly creates 10
items in sequence, (usually) causes the sheet to go into an infinite 
rendering loop. (You may need to change `10` to a higher/lower number
in order to easily reproduce the effect.) 

```
(async () => {
	const NUM_ITEMS = 10;
	const ACTOR_ID = "<YOUR ID HERE>"
	
	const actor = Actor.collection.get(ACTOR_ID)
	for (let i = 0; i < NUM_ITEMS; ++i) {
		const itemData = {
			name: `Test Item ${i}`,
			type: "loot",
			data: {
				description: "A test item"
			},
			img: "icons/svg/dice-target.svg",
		}
		await actor.createEmbeddedEntity("OwnedItem", itemData)
	}
})()
```

The exact cause of this is a Foundry DB limitation; it deals poorly with
concurrent requests. As you trigger an UPDATE to one embedded item 
at ~the same time as a CREATE (for e.g. the next item in the loop), the
two can be mutually harmful/produce undefined behaviour, including: 
failing to persist updates (to e.g. the "sort" field, thus
causing another sort loop to run), or  entities going missing 
altogether.

A simple debounce seems to smooth this over sufficiently well.
200ms was chosen arbitrarily; it may be possible to achieve the same
effect with a lower delay.